### PR TITLE
Stay in insertMode after window blur

### DIFF
--- a/vim_binding.js
+++ b/vim_binding.js
@@ -83,11 +83,23 @@ define([
     }
     original.handle_command_mode.call(this, cell);
   };
+
+  // we want to stay in the insert mode if we blur & focus our window
+  var wasInInsertBeforeBlur = false;
+  window.addEventListener("blur", function(){
+      var cell = namespace.notebook.get_selected_cell();
+      if(cell && cell.code_mirror){
+        var cm = cell.code_mirror;
+        wasInInsertBeforeBlur = cm.state.vim.insertMode;
+      }
+  });
   notebook.Notebook.prototype.handle_edit_mode = function(cell) {
     // Make sure that the CodeMirror is in Vim's Normal mode
-    if (cell.code_mirror) {
+    // except we were in insert mode before the last blur
+    if (cell.code_mirror && !wasInInsertBeforeBlur){
       CodeMirror.Vim.Jupyter.leaveInsertMode(cell.code_mirror);
     }
+    wasInInsertBeforeBlur = false;
     original.handle_edit_mode.call(this, cell);
   };
   notebook.Notebook.prototype.select_closest_cell = function(direction) {


### PR DESCRIPTION
Hey,

yep yet another PR from me ;-)

I have noticed that Jupyter automatically unfocuses the current cell on a window.blur event (e.g. shifting the focus to a different tab) and they also issue a focus call once the window gains the focus again. This means that we will leave and the enter the edit mode and thus we will exit the insertMode in `handle_edit_mode`.

Here I propose a simple fix to stay in the insertMode if we blurred the window before.
