### PR TITLE
Enable Ctrl-C Vim binding

### DIFF
--- a/vim_binding.js
+++ b/vim_binding.js
@@ -462,7 +462,6 @@ define([
       cm_config.keyMap = 'vim';
       cm_config.extraKeys = extend(cm_config.extraKeys || {}, {
         'Esc': leaveInsertOrNormalMode,
-        'Ctrl-C': false,  // To enable clipboard copy
       });
 
       // Apply default CodeMirror config to existing CodeMirror instances


### PR DESCRIPTION
Ctrl-Ins can be used instead for OS copy.
