### PR TITLE
Fix #66: Keyboard shortcut for inserting cell below/above

### DIFF
--- a/lib/jupyter/shortcuts.js
+++ b/lib/jupyter/shortcuts.js
@@ -54,7 +54,7 @@ define([
       'g,g': 'vim-binding-normal:select-first-cell',
       'shift-g': 'vim-binding-normal:select-last-cell',
       'o': 'jupyter-notebook:insert-cell-below',
-      'ctrl-o': 'jupyter-notebook:insert-cell-below',
+      'shift-o': 'jupyter-notebook:insert-cell-above',
       'z,z': 'jupyter-notebook:scroll-cell-center',
       'z,t': 'jupyter-notebook:scroll-cell-top',
       'shift-m': 'jupyter-notebook:merge-cells',


### PR DESCRIPTION
ctrl-o:insert-below -> shift-o:insert-above
