### PR TITLE
RFC: eval markdown when leaving a cell

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -41,6 +41,9 @@ define([
     if(line < first || line > last){
       var current_cell = ns.notebook.get_selected_cell();
       var key = '';
+      if (current_cell.cell_type == 'markdown') {
+          current_cell.execute();
+      }
       if (motionArgs.forward) {
         ns.notebook.select_next();
         key = 'j';

--- a/lib/jupyter/actions.js
+++ b/lib/jupyter/actions.js
@@ -60,6 +60,31 @@ define([
     }, 'run-cell-and-select-next', 'vim-binding');
 
     actions.register({
+      'help': 'run cell, select below',
+      'handler': function(env, event) {
+        env.notebook.command_mode();
+        if (env.notebook.get_selected_cell().cell_type == 'markdown') {
+            actions.call('jupyter-notebook:run-cell-and-select-next', event, env);
+        } else {
+            actions.call('jupyter-notebook:select-next-cell', event, env);
+        }
+        env.notebook.edit_mode();
+      }
+    }, 'select-next-cell-eval-markdown', 'vim-binding');
+
+    actions.register({
+      'help': 'run cell, select above',
+      'handler': function(env, event) {
+        env.notebook.command_mode();
+        if (env.notebook.get_selected_cell().cell_type == 'markdown') {
+            actions.call('jupyter-notebook:run-cell', event, env);
+        }
+        actions.call('jupyter-notebook:select-previous-cell', event, env);
+        env.notebook.edit_mode();
+      }
+    }, 'select-previous-cell-eval-markdown', 'vim-binding');
+
+    actions.register({
       'help': 'run selected cells',
       'handler': function(env, event) {
         env.notebook.command_mode();

--- a/lib/jupyter/shortcuts.js
+++ b/lib/jupyter/shortcuts.js
@@ -94,8 +94,8 @@ define([
       // Repeat operations
       'ctrl-y': 'vim-binding:scroll-up',
       'ctrl-e': 'vim-binding:scroll-down',
-      'ctrl-k': 'vim-binding:select-previous-cell', // require C-k unmapping in CodeMirror
-      'ctrl-j': 'vim-binding:select-next-cell',     // require C-j unmapping in CodeMirror
+      'ctrl-k': 'vim-binding:select-previous-cell-eval-markdown', // require C-k unmapping in CodeMirror
+      'ctrl-j': 'vim-binding:select-next-cell-eval-markdown',     // require C-j unmapping in CodeMirror
       'ctrl-shift-k': 'vim-binding:extend-selection-above',
       'ctrl-shift-j': 'vim-binding:extend-selection-below',
       'ctrl-shift-u': 'vim-binding:scroll-notebook-up',


### PR DESCRIPTION
### This PR is for
- [ ] Fix a reported issue : #XXX
- [ ] Fix a unreported issue : Write summary in a new section
- [ ] Add a reported feature implement : #XXX
- [x] Add a unreported feature implement : Write summary in a new section
- [ ] Other : Write summary in a new section
### Summary

This PR evaluates markdown when leaving a cell. I only captured the most common cases I use (j, k, ctrl-j, and ctrl-k) and I realize there are others e.g. ctrl-o, o. I did this because I find it annoying when I'm navigating through my notebook with the controls above and all my markdown is left unrendered. This seems to work for me, do others like it?
