### PR TITLE
Remove the dollars from bash snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ The procedure below is a most simple one for quick use (**A recommended way is d
 
 ```bash
 # Create required directory in case (optional)
-$ mkdir -p $(jupyter --data-dir)/nbextensions
+mkdir -p $(jupyter --data-dir)/nbextensions
 # Clone the repository
-$ cd $(jupyter --data-dir)/nbextensions
-$ git clone https://github.com/lambdalisue/jupyter-vim-binding vim_binding
+cd $(jupyter --data-dir)/nbextensions
+git clone https://github.com/lambdalisue/jupyter-vim-binding vim_binding
 # Activate the extension
-$ jupyter nbextension enable vim_binding/vim_binding
+jupyter nbextension enable vim_binding/vim_binding
 ```
 
 


### PR DESCRIPTION
Why not remove the dollars, so this can be copy pasted into the bash?