### PR TITLE
Add shortcuts from jupyter config file

### DIFF
--- a/lib/jupyter/shortcuts.js
+++ b/lib/jupyter/shortcuts.js
@@ -156,6 +156,10 @@ define([
       km.command_shortcuts,
       exports.get_default_command_shortcuts()
     );
+    exports.add_shortcuts(
+      km.command_shortcuts,
+      ((km.config.data.keys||{}).command||{}).bind
+    );
     km.edit_shortcuts.clear_shortcuts();
     exports.add_shortcuts(
       km.edit_shortcuts,
@@ -164,6 +168,10 @@ define([
     exports.add_shortcuts(
       km.edit_shortcuts,
       exports.get_default_edit_shortcuts()
+    );
+    exports.add_shortcuts(
+      km.edit_shortcuts,
+      ((km.config.data.keys||{}).edit||{}).bind
     );
   };
 


### PR DESCRIPTION
Currently any user defined shortcuts in the proper jupyter config
(edited via notebook dialog and persisted in nbconfig/notebook.json)
are blown away by the calls to clear_shortcuts. This change adds those
custom shortcuts back in.
