### PR TITLE
Remove trailing commas from parameter list in lib/jupyter/shortcuts.js

### DIFF
--- a/lib/jupyter/shortcuts.js
+++ b/lib/jupyter/shortcuts.js
@@ -171,11 +171,11 @@ define([
     if (km.config && km.config.data.keys) {
       exports.add_shortcuts(
         km.command_shortcuts,
-        (km.config.data.keys.command || {}).bind || {},
+        (km.config.data.keys.command || {}).bind || {}
       );
       exports.add_shortcuts(
         km.edit_shortcuts,
-        (km.config.data.keys.edit || {}).bind || {},
+        (km.config.data.keys.edit || {}).bind || {}
       );
     }
   };


### PR DESCRIPTION
Trailing commas in parameter lists are currently only supported by firefox
according to the following reference:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas

This broke me on chrome 55.0.2883.75 (64-bit).

### This PR is for

- [ ] Fix a reported issue : #XXX
- [x] Fix a unreported issue : Write summary in a new section
- [ ] Add a reported feature implement : #XXX
- [ ] Add a unreported feature implement : Write summary in a new section
- [ ] Other : Write summary in a new section

### Summary

Trailing commas in parameter lists are currently only supported by firefox
according to the following reference:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas

This broke me on chrome 55.0.2883.75 (64-bit)
